### PR TITLE
Only pass speech events to google voice.

### DIFF
--- a/saera.py
+++ b/saera.py
@@ -533,7 +533,9 @@ class Saera:
 			result = False
 			func = False
 
-		if(settings['use_google_voice'] == 'unrecognized' and result.startswith("I don't understand ")) or settings['use_google_voice'] == 'always':
+		if event == "speech-event" \
+			and ((settings['use_google_voice'] == 'unrecognized' and result.startswith("I don't understand ")) \
+				 or settings['use_google_voice'] == 'always'):
 			print "Sending to Google..."
 			cmd = r'wget -q -U "Mozilla/5.0" --post-file /tmp/saera/output.flac -O- '\
 				'--header="Content-Type: audio/x-flac; rate='+str(SAMPLE_RATE)+r'" "'\


### PR DESCRIPTION
This patch makes sure that Google Voice is not called if input is directly provided via the text input box at the top.

cheers,
  stesie
